### PR TITLE
Don't match multiple import statements at once when preprocessing.

### DIFF
--- a/preprocessor/index.js
+++ b/preprocessor/index.js
@@ -10,12 +10,12 @@ export function phosphorSvelteOptimize() {
       if (!filename || /node_modules/.test(filename)) return
 
       const re = new RegExp(
-        /import\s*{([\s\S]*?)\s*}\s*from\s*["']phosphor-svelte["']([\s\n]*;)?/g
+        /import\s*{(?<imports>[^}]*)}\s*from\s*["']phosphor-svelte["']([\s\n]*;)?/g
       )
 
       let output = new MagicString(content, { filename })
       for (let match of content.matchAll(re)) {
-        const modules = match[1]
+        const modules = match.groups["imports"]
           .trim()
           .replace(/,$/, "")
           .split(",")

--- a/tests/preprocessor.test.js
+++ b/tests/preprocessor.test.js
@@ -108,6 +108,32 @@ import type { Hourglass as HourglassAlias } from "phosphor-svelte";
 
         expect(result.code).toBe(output)
       })
+
+
+      it("only one import statement", async () => {
+        const processor = phosphorSvelteOptimize()
+        const content = `<script lang="ts">
+  import { isFinished } from '$lib/statuses';
+  import { goto, invalidate } from '$app/navigation';
+  import type { PageData } from './$types';
+  import { Tag as TagIcon, ArrowUpRight, GitBranch, GitCommit } from 'phosphor-svelte';
+</script>\n`;
+
+        const result = await preprocess(content, processor, {
+          filename: "App.svelte",
+        })
+        const output = `<script lang="ts">
+  import { isFinished } from '$lib/statuses';
+  import { goto, invalidate } from '$app/navigation';
+  import type { PageData } from './$types';
+  import TagIcon from "phosphor-svelte/lib/Tag";
+import ArrowUpRight from "phosphor-svelte/lib/ArrowUpRight";
+import GitBranch from "phosphor-svelte/lib/GitBranch";
+import GitCommit from "phosphor-svelte/lib/GitCommit";
+</script>\n`
+
+        expect(result.code).toBe(output)
+      })
     })
   })
 })


### PR DESCRIPTION
Ran into an issue where the expression matches multiple imports. Added a test case with the code "from the wild" and modified the regular expression to match `[^}]*` inside of the import group (everything not a closing bracket).