### PR TITLE
fix: vite plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phosphor-svelte",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "phosphor-svelte",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "estree-walker": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       },
       "peerDependencies": {
         "svelte": "^5.0.0 || ^5.0.0-next.96",
-        "vite": "^5.0.0"
+        "vite": ">=5"
       },
       "peerDependenciesMeta": {
         "vite": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phosphor-svelte",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A clean and friendly icon family for Svelte",
   "svelte": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "homepage": "https://phosphoricons.com",
   "peerDependencies": {
     "svelte": "^5.0.0 || ^5.0.0-next.96",
-    "vite": "^5.0.0"
+    "vite": ">=5"
   },
   "peerDependenciesMeta": {
     "vite": {

--- a/vite/index.js
+++ b/vite/index.js
@@ -1,6 +1,8 @@
 import MagicString from "magic-string";
 import { walk } from "estree-walker";
 
+const CSS_RE = /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;
+
 /**
  *
  * @returns {import("vite").Plugin}
@@ -15,6 +17,7 @@ export function sveltePhosphorOptimize() {
         )
       )
         return;
+      if (CSS_RE.test(id)) return;
 
       const s = new MagicString(code);
       let root = this.parse(code);

--- a/vite/index.js
+++ b/vite/index.js
@@ -1,7 +1,23 @@
 import MagicString from "magic-string";
 import { walk } from "estree-walker";
 
+const EXCLUDE_RE = /\/node_modules\/|\/\.svelte-kit\/|virtual:__sveltekit/;
 const CSS_RE = /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;
+
+function parseId(id) {
+  const parts = id.split("?", 2);
+  const filename = parts[0];
+  const rawQuery = parts[1];
+
+  const query = Object.fromEntries(new URLSearchParams(rawQuery));
+  for (const key in query) {
+    if (query[key] === "") {
+      query[key] = true;
+    }
+  }
+
+  return { filename, query };
+}
 
 /**
  *
@@ -11,13 +27,13 @@ export function sveltePhosphorOptimize() {
   return {
     name: "vite-plugin-svelte-phosphor-optimize",
     transform(code, id) {
+      const { query, filename } = parseId(id);
       if (
-        ["/node_modules/", "/.svelte-kit/", "virtual:__sveltekit"].some((p) =>
-          id.includes(p)
-        )
+        EXCLUDE_RE.test(filename) ||
+        CSS_RE.test(filename) ||
+        query.type === "style"
       )
         return;
-      if (CSS_RE.test(id)) return;
 
       const s = new MagicString(code);
       let root = this.parse(code);


### PR DESCRIPTION
- Exclude css files. Fix #28.
- Updated `vite` in `peerDependencies` to reflect >=5. Fix #29.