### PR TITLE
fix: exclude html files in the vite plugin (closes #35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ import { defineConfig } from "vite";
 import { sveltePhosphorOptimize } from "phosphor-svelte/vite";
 
 export default defineConfig({
-  plugins: [sveltePhosphorOptimize(), sveltekit()],
+  plugins: [sveltekit(), sveltePhosphorOptimize()],
 });
 ```
 

--- a/vite/index.js
+++ b/vite/index.js
@@ -3,6 +3,7 @@ import { walk } from "estree-walker";
 
 const EXCLUDE_RE = /\/node_modules\/|\/\.svelte-kit\/|virtual:__sveltekit/;
 const CSS_RE = /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;
+const HTML_RE = /\.(html|htm)(?:$|\?)/;
 
 function parseId(id) {
   const parts = id.split("?", 2);
@@ -31,6 +32,7 @@ export function sveltePhosphorOptimize() {
       if (
         EXCLUDE_RE.test(filename) ||
         CSS_RE.test(filename) ||
+        HTML_RE.test(filename) ||
         query.type === "style"
       )
         return;


### PR DESCRIPTION
Storybook builds fail because the plugin attempts to parse generated iframe.html as JavaScript. This update adds HTML file exclusion (similar to existing CSS exclusion) to prevent parsing errors during Storybook builds. #35

Changes:
- [x] Add HTML (and optionally HTM) to exclusion regex in `transform` hook check.
- [x] Update the `README.md` to use the correct usage of the plugin.
